### PR TITLE
Document pager installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ To include all these files, add this to the top of your <code>~/.gitconfig</code
        path = sixarm_git_gitconfig/gitconfig-github.txt
        path = sixarm_git_gitconfig/gitconfig-user.txt
 
+This repo configures git to use the `most` pager rather than `less` or
+`more`. You can install `most` like this:
+
+    # Homebrew, in OS X
+    brew install most
+
+    # Ubuntu
+    sudo aptitude install most
 
 ## Personalization
 


### PR DESCRIPTION
When I tried your configuration I was initially confused because git logs etc failed to paginate. Then I discovered I needed to install `most`. Here's an addition to the readme to help other people avoid my confusion.
