### PR TITLE
Match v, vv, vvv conventions with git log

### DIFF
--- a/gitconfig-alias.txt
+++ b/gitconfig-alias.txt
@@ -36,7 +36,7 @@
   g = grep
 
   # log - show commit logs.
-  l = log
+  lll = log
 
   # merge - join two or more development histories together.
   m = merge
@@ -118,7 +118,7 @@
   ll = log --pretty=format:'%ad %h %s' --abbrev-commit --date=short
 
   # log line longer summary: a graph, colors, one-line commit messages, and iso dates.
-  lll = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cblue[%cn]%Creset %Cgreen(%cr)%Creset' --abbrev-commit --date=iso
+  l = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cblue[%cn]%Creset %Cgreen(%cr)%Creset' --abbrev-commit --date=iso
 
   # ls-files - show information about files in the index and the working tree; like Unix "ls" command.
   ls = ls-files


### PR DESCRIPTION
I remapped the `l`, `ll`, and `lll` aliases such that those with more l's are more verbose. This matches the unix convention. Plus I tend to personally use `git lll` most frequently, and it gives a compact list of changes, so it is now just `git l`.
